### PR TITLE
Fix phpdoc comments

### DIFF
--- a/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/DocCommentSniff.php
+++ b/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/DocCommentSniff.php
@@ -14,7 +14,7 @@ class Barracuda_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sni
                                              'allow_multiple' => false,
                                             ),
                            '@package'    => array(
-                                             'required'       => true,
+                                             'required'       => false,
                                              'allow_multiple' => false,
                                             ),
                            '@subpackage' => array(
@@ -22,7 +22,7 @@ class Barracuda_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sni
                                              'allow_multiple' => false,
                                             ),
                            '@author'     => array(
-                                             'required'       => true,
+                                             'required'       => false,
                                              'allow_multiple' => true,
                                             ),
                            '@copyright'  => array(
@@ -38,7 +38,7 @@ class Barracuda_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sni
                                              'allow_multiple' => false,
                                             ),
                            '@link'       => array(
-                                             'required'       => true,
+                                             'required'       => false,
                                              'allow_multiple' => true,
                                             ),
                            '@see'        => array(

--- a/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/FunctionCommentSniff.php
@@ -1,0 +1,555 @@
+<?php
+/**
+ * Parses and verifies the doc comments for functions.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false) {
+    throw new PHP_CodeSniffer_Exception('Class PEAR_Sniffs_Commenting_FunctionCommentSniff not found');
+}
+
+/**
+ * Parses and verifies the doc comments for functions.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Barracuda_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting_FunctionCommentSniff
+{
+	protected $customAllowedTypes = array('bool', 'int');
+
+    /**
+     * Process the return comment of this function comment.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                  $stackPtr     The position of the current token
+     *                                           in the stack passed in $tokens.
+     * @param int                  $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processReturn(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Skip constructor and destructor.
+        $methodName      = $phpcsFile->getDeclarationName($stackPtr);
+        $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
+
+        $return = null;
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] === '@return') {
+                if ($return !== null) {
+                    $error = 'Only 1 @return tag is allowed in a function comment';
+                    $phpcsFile->addError($error, $tag, 'DuplicateReturn');
+                    return;
+                }
+
+                $return = $tag;
+            }
+        }
+
+        if ($isSpecialMethod === true) {
+            return;
+        }
+
+        if ($return !== null) {
+            $content = $tokens[($return + 2)]['content'];
+            if (empty($content) === true || $tokens[($return + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                $error = 'Return type missing for @return tag in function comment';
+                $phpcsFile->addError($error, $return, 'MissingReturnType');
+            } else {
+                // Check return type (can be multiple, separated by '|').
+                $typeNames      = explode('|', $content);
+                $suggestedNames = array();
+                foreach ($typeNames as $i => $typeName) {
+                    $suggestedName = PHP_CodeSniffer::suggestType($typeName);
+                    if (in_array($suggestedName, $suggestedNames) === false) {
+                        $suggestedNames[] = $suggestedName;
+						if ($suggestedName == 'boolean') {
+							$suggestedNames[] = 'bool';
+						}
+
+						if ($suggestedName == 'integer') {
+							$suggestedNames[] = 'int';
+						}
+                    }
+                }
+
+                $suggestedType = implode('|', $suggestedNames);
+                if ($content !== $suggestedType) {
+                    $error = 'Expected "%s" but found "%s" for function return type';
+                    $data  = array(
+                              $suggestedType,
+                              $content,
+                             );
+                    $fix   = $phpcsFile->addFixableError($error, $return, 'InvalidReturn', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($return + 2), $suggestedType);
+                    }
+                }
+
+                // If the return type is void, make sure there is
+                // no return statement in the function.
+                if ($content === 'void') {
+                    if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+                        $endToken = $tokens[$stackPtr]['scope_closer'];
+                        for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++) {
+                            if ($tokens[$returnToken]['code'] === T_CLOSURE) {
+                                $returnToken = $tokens[$returnToken]['scope_closer'];
+                                continue;
+                            }
+
+                            if ($tokens[$returnToken]['code'] === T_RETURN
+                                || $tokens[$returnToken]['code'] === T_YIELD
+                            ) {
+                                break;
+                            }
+                        }
+
+                        if ($returnToken !== $endToken) {
+                            // If the function is not returning anything, just
+                            // exiting, then there is no problem.
+                            $semicolon = $phpcsFile->findNext(T_WHITESPACE, ($returnToken + 1), null, true);
+                            if ($tokens[$semicolon]['code'] !== T_SEMICOLON) {
+                                $error = 'Function return type is void, but function contains return statement';
+                                $phpcsFile->addError($error, $return, 'InvalidReturnVoid');
+                            }
+                        }
+                    }//end if
+                } else if ($content !== 'mixed') {
+                    // If return type is not void, there needs to be a return statement
+                    // somewhere in the function that returns something.
+                    if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+                        $endToken    = $tokens[$stackPtr]['scope_closer'];
+                        $returnToken = $phpcsFile->findNext(array(T_RETURN, T_YIELD), $stackPtr, $endToken);
+                        if ($returnToken === false) {
+                            $error = 'Function return type is not void, but function has no return statement';
+                            $phpcsFile->addError($error, $return, 'InvalidNoReturn');
+                        } else {
+                            $semicolon = $phpcsFile->findNext(T_WHITESPACE, ($returnToken + 1), null, true);
+                            if ($tokens[$semicolon]['code'] === T_SEMICOLON) {
+                                $error = 'Function return type is not void, but function is returning void here';
+                                $phpcsFile->addError($error, $returnToken, 'InvalidReturnNotVoid');
+                            }
+                        }
+                    }
+                }//end if
+            }//end if
+        } else {
+            $error = 'Missing @return tag in function comment';
+            $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
+        }//end if
+
+    }//end processReturn()
+
+
+    /**
+     * Process any throw tags that this function comment has.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                  $stackPtr     The position of the current token
+     *                                           in the stack passed in $tokens.
+     * @param int                  $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processThrows(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $throws = array();
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] !== '@throws') {
+                continue;
+            }
+
+            $exception = null;
+            $comment   = null;
+            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
+                $matches = array();
+                preg_match('/([^\s]+)(?:\s+(.*))?/', $tokens[($tag + 2)]['content'], $matches);
+                $exception = $matches[1];
+                if (isset($matches[2]) === true && trim($matches[2]) !== '') {
+                    $comment = $matches[2];
+                }
+            }
+
+            if ($exception === null) {
+                $error = 'Exception type and comment missing for @throws tag in function comment';
+                $phpcsFile->addError($error, $tag, 'InvalidThrows');
+            } else if ($comment === null) {
+                $error = 'Comment missing for @throws tag in function comment';
+                $phpcsFile->addError($error, $tag, 'EmptyThrows');
+            } else {
+                // Any strings until the next tag belong to this comment.
+                if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                    $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
+                } else {
+                    $end = $tokens[$commentStart]['comment_closer'];
+                }
+
+                for ($i = ($tag + 3); $i < $end; $i++) {
+                    if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                        $comment .= ' '.$tokens[$i]['content'];
+                    }
+                }
+
+                // Starts with a capital letter and ends with a fullstop.
+                $firstChar = $comment{0};
+                if (strtoupper($firstChar) !== $firstChar) {
+                    $error = '@throws tag comment must start with a capital letter';
+                    $phpcsFile->addError($error, ($tag + 2), 'ThrowsNotCapital');
+                }
+
+                $lastChar = substr($comment, -1);
+                if ($lastChar !== '.') {
+                    $error = '@throws tag comment must end with a full stop';
+                    $phpcsFile->addError($error, ($tag + 2), 'ThrowsNoFullStop');
+                }
+            }//end if
+        }//end foreach
+
+    }//end processThrows()
+
+
+    /**
+     * Process the function parameter comments.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                  $stackPtr     The position of the current token
+     *                                           in the stack passed in $tokens.
+     * @param int                  $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $params  = array();
+        $maxType = 0;
+        $maxVar  = 0;
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] !== '@param') {
+                continue;
+            }
+
+            $type         = '';
+            $typeSpace    = 0;
+            $var          = '';
+            $varSpace     = 0;
+            $comment      = '';
+            $commentLines = array();
+            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
+                $matches = array();
+                preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+
+                $typeLen   = strlen($matches[1]);
+                $type      = trim($matches[1]);
+                $typeSpace = ($typeLen - strlen($type));
+                $typeLen   = strlen($type);
+                if ($typeLen > $maxType) {
+                    $maxType = $typeLen;
+                }
+
+                if (isset($matches[2]) === true) {
+                    $var    = $matches[2];
+                    $varLen = strlen($var);
+                    if ($varLen > $maxVar) {
+                        $maxVar = $varLen;
+                    }
+
+                    if (isset($matches[4]) === true) {
+                        $varSpace       = strlen($matches[3]);
+                        $comment        = $matches[4];
+                        $commentLines[] = array(
+                                           'comment' => $comment,
+                                           'token'   => ($tag + 2),
+                                           'indent'  => $varSpace,
+                                          );
+
+                        // Any strings until the next tag belong to this comment.
+                        if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                            $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
+                        } else {
+                            $end = $tokens[$commentStart]['comment_closer'];
+                        }
+
+                        for ($i = ($tag + 3); $i < $end; $i++) {
+                            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                                $indent = 0;
+                                if ($tokens[($i - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                                    $indent = strlen($tokens[($i - 1)]['content']);
+                                }
+
+                                $comment       .= ' '.$tokens[$i]['content'];
+                                $commentLines[] = array(
+                                                   'comment' => $tokens[$i]['content'],
+                                                   'token'   => $i,
+                                                   'indent'  => $indent,
+                                                  );
+                            }
+                        }
+                    } else {
+                        $error = 'Missing parameter comment';
+                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
+                        $commentLines[] = array('comment' => '');
+                    }//end if
+                } else {
+                    $error = 'Missing parameter name';
+                    $phpcsFile->addError($error, $tag, 'MissingParamName');
+                }//end if
+            } else {
+                $error = 'Missing parameter type';
+                $phpcsFile->addError($error, $tag, 'MissingParamType');
+            }//end if
+
+            $params[] = array(
+                         'tag'          => $tag,
+                         'type'         => $type,
+                         'var'          => $var,
+                         'comment'      => $comment,
+                         'commentLines' => $commentLines,
+                         'type_space'   => $typeSpace,
+                         'var_space'    => $varSpace,
+                        );
+        }//end foreach
+
+        $realParams  = $phpcsFile->getMethodParameters($stackPtr);
+        $foundParams = array();
+
+        foreach ($params as $pos => $param) {
+            // If the type is empty, the whole line is empty.
+            if ($param['type'] === '') {
+                continue;
+            }
+
+            // Check the param type value.
+            $typeNames = explode('|', $param['type']);
+            foreach ($typeNames as $typeName) {
+                $suggestedName = PHP_CodeSniffer::suggestType($typeName);
+                if ($typeName !== $suggestedName && !in_array($typeName, $this->customAllowedTypes)) {
+                    $error = 'Expected "%s" but found "%s" for parameter type';
+                    $data  = array(
+                              $suggestedName,
+                              $typeName,
+                             );
+
+                    $fix = $phpcsFile->addFixableError($error, $param['tag'], 'IncorrectParamVarName', $data);
+                    if ($fix === true) {
+                        $content  = $suggestedName;
+                        $content .= str_repeat(' ', $param['type_space']);
+                        $content .= $param['var'];
+                        $content .= str_repeat(' ', $param['var_space']);
+                        if (isset($param['commentLines'][0]) === true) {
+                            $content .= $param['commentLines'][0]['comment'];
+                        }
+
+                        $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
+                    }
+                } else if (count($typeNames) === 1 && !in_array($typeName, $this->customAllowedTypes)) {
+                    // Check type hint for array and custom type.
+                    $suggestedTypeHint = '';
+                    if (strpos($suggestedName, 'array') !== false || substr($suggestedName, -2) === '[]') {
+                        $suggestedTypeHint = 'array';
+                    } else if (strpos($suggestedName, 'callable') !== false) {
+                        $suggestedTypeHint = 'callable';
+                    } else if (strpos($suggestedName, 'callback') !== false) {
+                        $suggestedTypeHint = 'callable';
+                    } else if (in_array($typeName, PHP_CodeSniffer::$allowedTypes) === false) {
+                        $suggestedTypeHint = $suggestedName;
+                    }
+
+                    if ($suggestedTypeHint !== '' && isset($realParams[$pos]) === true) {
+                        $typeHint = $realParams[$pos]['type_hint'];
+                        if ($typeHint === '') {
+                            $error = 'Type hint "%s" missing for %s';
+                            $data  = array(
+                                      $suggestedTypeHint,
+                                      $param['var'],
+                                     );
+                            $phpcsFile->addError($error, $stackPtr, 'TypeHintMissing', $data);
+                        } else if ($typeHint !== substr($suggestedTypeHint, (strlen($typeHint) * -1))) {
+                            $error = 'Expected type hint "%s"; found "%s" for %s';
+                            $data  = array(
+                                      $suggestedTypeHint,
+                                      $typeHint,
+                                      $param['var'],
+                                     );
+                            $phpcsFile->addError($error, $stackPtr, 'IncorrectTypeHint', $data);
+                        }
+                    } else if ($suggestedTypeHint === '' && isset($realParams[$pos]) === true) {
+                        $typeHint = $realParams[$pos]['type_hint'];
+                        if ($typeHint !== '') {
+                            $error = 'Unknown type hint "%s" found for %s';
+                            $data  = array(
+                                      $typeHint,
+                                      $param['var'],
+                                     );
+                            $phpcsFile->addError($error, $stackPtr, 'InvalidTypeHint', $data);
+                        }
+                    }//end if
+                }//end if
+            }//end foreach
+
+            if ($param['var'] === '') {
+                continue;
+            }
+
+            $foundParams[] = $param['var'];
+
+            // Check number of spaces after the type.
+            $spaces = ($maxType - strlen($param['type']) + 1);
+            if ($param['type_space'] !== $spaces) {
+                $error = 'Expected %s spaces after parameter type; %s found';
+                $data  = array(
+                          $spaces,
+                          $param['type_space'],
+                         );
+
+                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamType', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+
+                    $content  = $param['type'];
+                    $content .= str_repeat(' ', $spaces);
+                    $content .= $param['var'];
+                    $content .= str_repeat(' ', $param['var_space']);
+                    $content .= $param['commentLines'][0]['comment'];
+                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
+
+                    // Fix up the indent of additional comment lines.
+                    foreach ($param['commentLines'] as $lineNum => $line) {
+                        if ($lineNum === 0
+                            || $param['commentLines'][$lineNum]['indent'] === 0
+                        ) {
+                            continue;
+                        }
+
+                        $newIndent = ($param['commentLines'][$lineNum]['indent'] + $spaces - $param['type_space']);
+                        $phpcsFile->fixer->replaceToken(
+                            ($param['commentLines'][$lineNum]['token'] - 1),
+                            str_repeat(' ', $newIndent)
+                        );
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }//end if
+            }//end if
+
+            // Make sure the param name is correct.
+            if (isset($realParams[$pos]) === true) {
+                $realName = $realParams[$pos]['name'];
+                if ($realName !== $param['var']) {
+                    $code = 'ParamNameNoMatch';
+                    $data = array(
+                             $param['var'],
+                             $realName,
+                            );
+
+                    $error = 'Doc comment for parameter %s does not match ';
+                    if (strtolower($param['var']) === strtolower($realName)) {
+                        $error .= 'case of ';
+                        $code   = 'ParamNameNoCaseMatch';
+                    }
+
+                    $error .= 'actual variable name %s';
+
+                    $phpcsFile->addError($error, $param['tag'], $code, $data);
+                }
+            } else if (substr($param['var'], -4) !== ',...') {
+                // We must have an extra parameter comment.
+                $error = 'Superfluous parameter comment';
+                $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
+            }//end if
+
+            if ($param['comment'] === '') {
+                continue;
+            }
+
+            // Check number of spaces after the var name.
+            $spaces = ($maxVar - strlen($param['var']) + 1);
+            if ($param['var_space'] !== $spaces) {
+                $error = 'Expected %s spaces after parameter name; %s found';
+                $data  = array(
+                          $spaces,
+                          $param['var_space'],
+                         );
+
+                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamName', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+
+                    $content  = $param['type'];
+                    $content .= str_repeat(' ', $param['type_space']);
+                    $content .= $param['var'];
+                    $content .= str_repeat(' ', $spaces);
+                    $content .= $param['commentLines'][0]['comment'];
+                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
+
+                    // Fix up the indent of additional comment lines.
+                    foreach ($param['commentLines'] as $lineNum => $line) {
+                        if ($lineNum === 0
+                            || $param['commentLines'][$lineNum]['indent'] === 0
+                        ) {
+                            continue;
+                        }
+
+                        $newIndent = ($param['commentLines'][$lineNum]['indent'] + $spaces - $param['var_space']);
+                        $phpcsFile->fixer->replaceToken(
+                            ($param['commentLines'][$lineNum]['token'] - 1),
+                            str_repeat(' ', $newIndent)
+                        );
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }//end if
+            }//end if
+
+            // Param comments must start with a capital letter and end with the full stop.
+            $firstChar = $param['comment']{0};
+            if (preg_match('|\p{Lu}|u', $firstChar) === 0) {
+                $error = 'Parameter comment must start with a capital letter';
+                $phpcsFile->addError($error, $param['tag'], 'ParamCommentNotCapital');
+            }
+
+            $lastChar = substr($param['comment'], -1);
+            if ($lastChar !== '.') {
+                $error = 'Parameter comment must end with a full stop';
+                $phpcsFile->addError($error, $param['tag'], 'ParamCommentFullStop');
+            }
+        }//end foreach
+
+        $realNames = array();
+        foreach ($realParams as $realParam) {
+            $realNames[] = $realParam['name'];
+        }
+
+        // Report missing comments.
+        $diff = array_diff($realNames, $foundParams);
+        foreach ($diff as $neededParam) {
+            $error = 'Doc comment for parameter "%s" missing';
+            $data  = array($neededParam);
+            $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
+        }
+
+    }//end processParams()
+
+
+}//end class

--- a/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/VariableCommentSniff.php
+++ b/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/VariableCommentSniff.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Parses and verifies the variable doc comment.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+if (class_exists('PHP_CodeSniffer_Standards_AbstractVariableSniff', true) === false) {
+    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found');
+}
+
+/**
+ * Parses and verifies the variable doc comment.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+class Barracuda_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff
+{
+	protected $customAllowedTypes = array('bool', 'int');
+
+    /**
+     * Called to process class member vars.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $commentToken = array(
+                         T_COMMENT,
+                         T_DOC_COMMENT_CLOSE_TAG,
+                        );
+
+        $commentEnd = $phpcsFile->findPrevious($commentToken, $stackPtr);
+        if ($commentEnd === false) {
+            $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
+            return;
+        }
+
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            $phpcsFile->addError('You must use "/**" style comments for a member variable comment', $stackPtr, 'WrongStyle');
+            return;
+        } else if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
+            return;
+        } else {
+            // Make sure the comment we have found belongs to us.
+            $commentFor = $phpcsFile->findNext(array(T_VARIABLE, T_CLASS, T_INTERFACE), ($commentEnd + 1));
+            if ($commentFor !== $stackPtr) {
+                $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
+                return;
+            }
+        }
+
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+
+        $foundVar = null;
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] === '@var') {
+                if ($foundVar !== null) {
+                    $error = 'Only one @var tag is allowed in a member variable comment';
+                    $phpcsFile->addError($error, $tag, 'DuplicateVar');
+                } else {
+                    $foundVar = $tag;
+                }
+            } else if ($tokens[$tag]['content'] === '@see') {
+                // Make sure the tag isn't empty.
+                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
+                if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
+                    $error = 'Content missing for @see tag in member variable comment';
+                    $phpcsFile->addError($error, $tag, 'EmptySees');
+                }
+            } else {
+                $error = '%s tag is not allowed in member variable comment';
+                $data  = array($tokens[$tag]['content']);
+                $phpcsFile->addWarning($error, $tag, 'TagNotAllowed', $data);
+            }//end if
+        }//end foreach
+
+        // The @var tag is the only one we require.
+        if ($foundVar === null) {
+            $error = 'Missing @var tag in member variable comment';
+            $phpcsFile->addError($error, $commentEnd, 'MissingVar');
+            return;
+        }
+
+        $firstTag = $tokens[$commentStart]['comment_tags'][0];
+        if ($foundVar !== null && $tokens[$firstTag]['content'] !== '@var') {
+            $error = 'The @var tag must be the first tag in a member variable comment';
+            $phpcsFile->addError($error, $foundVar, 'VarOrder');
+        }
+
+        // Make sure the tag isn't empty and has the correct padding.
+        $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $foundVar, $commentEnd);
+        if ($string === false || $tokens[$string]['line'] !== $tokens[$foundVar]['line']) {
+            $error = 'Content missing for @var tag in member variable comment';
+            $phpcsFile->addError($error, $foundVar, 'EmptyVar');
+            return;
+        }
+
+        $varType       = $tokens[($foundVar + 2)]['content'];
+        $suggestedType = PHP_CodeSniffer::suggestType($varType);
+        if ($varType !== $suggestedType && !in_array($varType, $this->customAllowedTypes)) {
+            $error = 'Expected "%s" but found "%s" for @var tag in member variable comment';
+            $data  = array(
+                      $suggestedType,
+                      $varType,
+                     );
+            $phpcsFile->addError($error, ($foundVar + 2), 'IncorrectVarType', $data);
+        }
+
+    }//end processMemberVar()
+
+
+    /**
+     * Called to process a normal variable.
+     *
+     * Not required for this sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The PHP_CodeSniffer file where this token was found.
+     * @param int                  $stackPtr  The position where the double quoted
+     *                                        string was found.
+     *
+     * @return void
+     */
+    protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+
+    }//end processVariable()
+
+
+    /**
+     * Called to process variables found in double quoted strings.
+     *
+     * Not required for this sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The PHP_CodeSniffer file where this token was found.
+     * @param int                  $stackPtr  The position where the double quoted
+     *                                        string was found.
+     *
+     * @return void
+     */
+    protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+
+    }//end processVariableInString()
+
+
+}//end class

--- a/PHP_CodeSniffer/Barracuda/ruleset.xml
+++ b/PHP_CodeSniffer/Barracuda/ruleset.xml
@@ -33,11 +33,8 @@
 	</rule>
 
 	<!-- Configure for commenting -->
-	<rule ref="Barracuda.Commenting.DocComment" />
-	<rule ref="Squiz.Commenting.FunctionComment" />
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag" />
 	<rule ref="Squiz.Commenting.ClassComment" />
-	<rule ref="Squiz.Commenting.VariableComment" />
 
 	<!-- Configure for tabs -->
 	<!-- <arg name="tab-width" value="4"/>


### PR DESCRIPTION
Such as not accepting int and bool types and requiring some tags be present which don't need to be.
Just modified the Squiz sniffs.
Also, cleaned up the ruleset as all Barracuda sniffs are added by default.
