### PR TITLE
Fix bool & int return types

### DIFF
--- a/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/FunctionCommentSniff.php
@@ -31,7 +31,15 @@ if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false)
  */
 class Barracuda_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting_FunctionCommentSniff
 {
-	protected $customAllowedTypes = array('bool', 'int');
+	protected $allowedTypes = array(
+		'int',
+		'bool',
+	);
+
+	public function __construct()
+	{
+		PHP_CodeSniffer::$allowedTypes = array_merge(PHP_CodeSniffer::$allowedTypes, $this->allowedTypes);
+	}
 
     /**
      * Process the return comment of this function comment.
@@ -81,13 +89,6 @@ class Barracuda_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Comme
                     $suggestedName = PHP_CodeSniffer::suggestType($typeName);
                     if (in_array($suggestedName, $suggestedNames) === false) {
                         $suggestedNames[] = $suggestedName;
-						if ($suggestedName == 'boolean') {
-							$suggestedNames[] = 'bool';
-						}
-
-						if ($suggestedName == 'integer') {
-							$suggestedNames[] = 'int';
-						}
                     }
                 }
 

--- a/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/VariableCommentSniff.php
+++ b/PHP_CodeSniffer/Barracuda/Sniffs/Commenting/VariableCommentSniff.php
@@ -32,7 +32,15 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractVariableSniff', true) === fa
 
 class Barracuda_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff
 {
-	protected $customAllowedTypes = array('bool', 'int');
+	protected $allowedTypes = array(
+		'bool',
+		'int',
+	);
+
+	public function __construct()
+	{
+		PHP_CodeSniffer::$allowedTypes = array_merge(PHP_CodeSniffer::$allowedTypes, $this->allowedTypes);
+	}
 
     /**
      * Called to process class member vars.
@@ -120,7 +128,7 @@ class Barracuda_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_S
 
         $varType       = $tokens[($foundVar + 2)]['content'];
         $suggestedType = PHP_CodeSniffer::suggestType($varType);
-        if ($varType !== $suggestedType && !in_array($varType, $this->customAllowedTypes)) {
+        if ($varType !== $suggestedType) {
             $error = 'Expected "%s" but found "%s" for @var tag in member variable comment';
             $data  = array(
                       $suggestedType,


### PR DESCRIPTION
Going to try to get $allowedTypes registered prior to the Sniffs files
soon. Requires an upstream change though.
