### PR TITLE
Removed requirement for a File-wide PHPDoc

### DIFF
--- a/PHP_CodeSniffer/Barracuda/ruleset.xml
+++ b/PHP_CodeSniffer/Barracuda/ruleset.xml
@@ -22,6 +22,8 @@
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
 		<!-- Exclude spacing around parenthesis checks -->
 		<exclude name="PSR2.ControlStructures.ControlStructureSpacing"/>
+		<!-- Exclude requiring a doc block for an entire file -->
+		<exclude name="Barracuda.Commenting.DocComment.Missing"/>
 	</rule>
 
 	<!-- Configure for concatenation operator spacing -->


### PR DESCRIPTION
 Basically, the file-wide PHPDoc seems a bit redundant in our modern code, as we require docs for classes and functions.
